### PR TITLE
Modification image service php docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,0 @@
-FROM php:8.1.2-apache
-
-RUN apt-get update && apt-get install -y docker-php-ext-install pdo pdo_pgsql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   php:
-    build: .
+    image: flauz/pdo-apache-pdopgsql
     volumes:
       - ./:/var/www/html/
     ports:


### PR DESCRIPTION
# Description

Dockerfile contenant l'image php avec l'installation de pdo et de l'extension pdo postgres à été build et push sur Dockerhub.
Le Dockerfile à été supprimé du projet.
Le docker-compose intègre désormais la nouvelle image "flauz/pdo-apache-pdopgsql"

Fixes # (issue)

## Type de changement

Cochez les options pertinentes

- [ ] Correction de bug
- [x] Nouvelle fonctionnalité
- [ ] Breaking change
- [ ] Cette modification nécessite une mise à jour de la documentation

# Checklist :

- [x] Mon code suit les directives de ce projet
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code lorsque cela était nécessaire
- [x] J'ai apporté les modifications correspondantes à la documentation
- [x] Mes modifications ne génèrent aucun nouveau warning